### PR TITLE
Adds functionality to find the best selling day for an item

### DIFF
--- a/app/controllers/api/v1/items/best_day_controller.rb
+++ b/app/controllers/api/v1/items/best_day_controller.rb
@@ -1,0 +1,5 @@
+class Api::V1::Items::BestDayController < ApplicationController
+  def show
+    @best_day = Item.find_by(id: params[:item_id]).best_day
+  end
+end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -8,4 +8,16 @@ class Item < ApplicationRecord
   def unit_price_in_dollars
     '%.2f' % (self.unit_price / 100.0)
   end
+
+  def best_day
+    woo = self.invoices.joins('INNER JOIN transactions
+                               ON transactions.invoice_id = invoices.id')
+                        .where('transactions.result = ?', 'success')
+                        .select('invoices.created_at, SUM(invoice_items.quantity) AS items_sold')
+                        .group('invoices.id')
+                        .order('items_sold DESC, invoices.created_at DESC')
+                        .limit(1)
+                        .first
+                        .created_at
+  end
 end

--- a/app/views/api/v1/items/best_day/show.json.jbuilder
+++ b/app/views/api/v1/items/best_day/show.json.jbuilder
@@ -1,0 +1,1 @@
+json.best_day @best_day

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,6 +25,7 @@ Rails.application.routes.draw do
         scope module: 'items' do
           get 'invoice_items', to: 'invoice_items#index'
           get 'merchant', to: 'merchant#show'
+          get 'best_day', to: 'best_day#show'
         end
       end
 

--- a/spec/requests/api/v1/items_request_spec.rb
+++ b/spec/requests/api/v1/items_request_spec.rb
@@ -115,5 +115,16 @@ RSpec.describe 'Items API' do
    expect(actual['name']).to eq('Pierre')
  end
    
-   
+ it 'returns the date with the most sales for the given item using the invoice date' do
+   item = create(:item)
+   invoice1 = create(:invoice, created_at: '2012-03-23T10:55:29.000Z')
+   invoice_item1 = create(:invoice_item, invoice_id: invoice1.id, item_id: item.id, quantity: 2)
+   invoice2 = create(:invoice, created_at: '2012-04-23T10:55:29.000Z')
+   invoice_item2 = create(:invoice_item, invoice_id: invoice2.id, item_id: item.id)
+
+   get "/api/v1/items/#{item.id}/best_day.json"
+   actual = JSON.parse(response.body)
+
+   expect(actual['best_day']).to eq('2012-03-23T10:55:29.000Z')
+ end
 end

--- a/spec/requests/api/v1/items_request_spec.rb
+++ b/spec/requests/api/v1/items_request_spec.rb
@@ -114,13 +114,15 @@ RSpec.describe 'Items API' do
 
    expect(actual['name']).to eq('Pierre')
  end
-   
+
  it 'returns the date with the most sales for the given item using the invoice date' do
    item = create(:item)
    invoice1 = create(:invoice, created_at: '2012-03-23T10:55:29.000Z')
    invoice_item1 = create(:invoice_item, invoice_id: invoice1.id, item_id: item.id, quantity: 2)
+   create(:transaction, invoice_id: invoice1.id, result: 'success')
    invoice2 = create(:invoice, created_at: '2012-04-23T10:55:29.000Z')
    invoice_item2 = create(:invoice_item, invoice_id: invoice2.id, item_id: item.id)
+   create(:transaction, invoice_id: invoice2.id, result: 'success')
 
    get "/api/v1/items/#{item.id}/best_day.json"
    actual = JSON.parse(response.body)
@@ -132,8 +134,10 @@ RSpec.describe 'Items API' do
    item = create(:item)
    invoice1 = create(:invoice, created_at: '2012-03-23T10:55:29.000Z')
    invoice_item1 = create(:invoice_item, invoice_id: invoice1.id, item_id: item.id, quantity: 2)
+   create(:transaction, invoice_id: invoice1.id, result: 'success')
    invoice2 = create(:invoice, created_at: '2012-04-23T10:55:29.000Z')
    invoice_item2 = create(:invoice_item, invoice_id: invoice2.id, item_id: item.id, quantity: 2)
+   create(:transaction, invoice_id: invoice2.id, result: 'success')
 
    get "/api/v1/items/#{item.id}/best_day.json"
    actual = JSON.parse(response.body)

--- a/spec/requests/api/v1/items_request_spec.rb
+++ b/spec/requests/api/v1/items_request_spec.rb
@@ -127,4 +127,17 @@ RSpec.describe 'Items API' do
 
    expect(actual['best_day']).to eq('2012-03-23T10:55:29.000Z')
  end
+
+ it 'returns the most recent day if the sales are tied' do
+   item = create(:item)
+   invoice1 = create(:invoice, created_at: '2012-03-23T10:55:29.000Z')
+   invoice_item1 = create(:invoice_item, invoice_id: invoice1.id, item_id: item.id, quantity: 2)
+   invoice2 = create(:invoice, created_at: '2012-04-23T10:55:29.000Z')
+   invoice_item2 = create(:invoice_item, invoice_id: invoice2.id, item_id: item.id, quantity: 2)
+
+   get "/api/v1/items/#{item.id}/best_day.json"
+   actual = JSON.parse(response.body)
+
+   expect(actual['best_day']).to eq('2012-04-23T10:55:29.000Z')
+ end
 end


### PR DESCRIPTION
GET /api/v1/items/:id/best_day returns the date with the most sales for the given item using the invoice date. If there are multiple days with equal number of sales, return the most recent day.